### PR TITLE
Initial AnimeZ

### DIFF
--- a/quiCKIE.user.js
+++ b/quiCKIE.user.js
@@ -653,8 +653,26 @@ if ( primaryDomain == 'animebytes' ) {
     // Home | Browse| Bookmarks
 
     let trackerHandlingOptions = {
-        downloadELementsSelector: 'a[href^="https://animez.to/torrents/"][href$="/download"]',
+        downloadElementsSelector: 'a[href^="https://animez.to/torrents/"][href$="/download"]',
     }
+    
+    if ( pageURL.match(/\/torrents\/\d+/) ) {
+
+        trackerHandlingOptions.bunnyButtonText = '🐰 quiCKIE'
+        trackerHandlingOptions.bunnyButtonAddStyles = `
+            background: #4263eb;
+            border-radius: 8px;
+            border 1px solid transparent;
+            color: #f9fafb;
+            box-shadow: 0 1px 1px rgba(229, 231, 235, .06);
+            padding: 0.6875rem 1.5rem;
+            font-size: 1rem;
+            font-weight: 500;
+            line-height: 1.5rem;
+        `
+    }
+            
+
     quickieTrackerHandler(trackerHandlingOptions)
 
 } else if ( primaryDomain == 'anthelion' ) {

--- a/quiCKIE.user.js
+++ b/quiCKIE.user.js
@@ -1001,6 +1001,25 @@ if ( primaryDomain == 'animebytes' ) {
     let trackerHandlingOptions = {
         downloadElementsSelector: 'a[href^="https://exoticaz.to/download/torrent/"]',
     }
+    if ( pageURL.match(/\/torrent\/\d+/) ) {
+
+        trackerHandlingOptions.bunnyButtonText = '🐰 quiCKIE'
+        trackerHandlingOptions.bunnyButtonAddStyles = `
+            background: #e94a93;
+            color: #e8e6e3;
+            font-size: .8203125rem;
+            display: inline-block;
+            padding: .2rem .7rem;
+            border-radius: 0;
+            font-weight: 400
+            border: 1px solid transparent;
+            line-height: 1;
+            font-family: 'Roboto';
+            margin-left: 5px;
+            margin-right: 1px;
+            margin-top: 3px;
+        `
+    }
 
     quickieTrackerHandler(trackerHandlingOptions)
 

--- a/quiCKIE.user.js
+++ b/quiCKIE.user.js
@@ -39,6 +39,10 @@
 // @match   https://alpharatio.cc/top10.php*
 // @match   https://alpharatio.cc/torrents.php*
 
+// @match   https://animez.to/
+// @match   https://animez.to/torrents*
+// @match   https://animez.to/torrent-bookmarks*
+
 // @match   https://animebytes.tv/alltorrents.php?*&userid=*
 // @match   https://animebytes.tv/artist.php?id=*
 // @match   https://animebytes.tv/bookmarks.php*
@@ -270,6 +274,12 @@ const settingsPanelTrackers = [
         trackerName: 'AlphaRatio',
         homepageURL: 'https://alpharatio.cc',
         primaryDomain: 'alpharatio',
+    },
+
+    {
+        trackerName: 'AnimeZ',
+        homepageURL: 'https://animez.to',
+        primaryDomain: 'animez',
     },
 
     {
@@ -636,6 +646,15 @@ if ( primaryDomain == 'animebytes' ) {
         downloadElementsSelector: 'a[href^="torrents.php?action=download&id="]',
     }
 
+    quickieTrackerHandler(trackerHandlingOptions)
+
+} else if ( primaryDomain == 'animez' ) {
+    // --------------------------------- AnimeZ ------------------------------------
+    // Home | Browse| Bookmarks
+
+    let trackerHandlingOptions = {
+        downloadELementsSelector: 'a[href^="https://animez.to/torrents/"][href$="/download"]',
+    }
     quickieTrackerHandler(trackerHandlingOptions)
 
 } else if ( primaryDomain == 'anthelion' ) {


### PR DESCRIPTION
The AvistaZ team has finally modernized their anime tracker (animetorrents.me -> animez.to), however I am getting an odd error
The script has executed sucessfully, but the initial search found no download elements for which to make BunnyButtons 🐰

```
If you are not seeing any BunnyButtons, this usually means that either the CSS selector used for matching the AnimeZ download buttons needs to be updated or that you are on a site\page that has pagination.

Paste this command into your browser console, if the returned list is empty, then the CSS Selector is returning no results and needs updating: document.querySelectorAll('undefined')

Refer to the quiCKIE GitHub WiKi for a guide on adding a new tracker, which has a section on how to determine\update the CSS selector.

If the CSS selector is returning results but there are still no BunnyButtons, it is likely due to pagination. Use quiCKIE's 🔁 setting for pagination compatability.

ℹ️ If you are reading this and your BunnyButtons are working fine, you can safely ignore this message. It is likely that the pagination of your current site did not finish loading before quiCKIE performed this first scan.

ℹ️ If this page has no download elements to begin with, it means that one of the @match URL's for AnimeZ is running quiCKIE on pages it should not. Please report this so that quiCKIE won't waste your resources and can be improved.
```

My selector is not being picked up when quiCKIE is run. I know my selector works because I tested it in the console and it finds all of the download buttons. I also tried a quick test with `enablePaginationLooping` with no change in behavior. 