### PR TITLE
very minor: added obscure nebulance.io @match

### DIFF
--- a/quiCKIE.user.js
+++ b/quiCKIE.user.js
@@ -168,6 +168,7 @@
 // @match   https://nebulance.io/bookmarks.php*
 // @match   https://nebulance.io/top10.php*
 // @match   https://nebulance.io/torrents.php*
+// @match   https://nebulance.io/details.php*
 
 // @include   /^https://(sukebei\.)?nyaa\.\w+/.*/
 // @include   /^https://(sukebei\.)?nyaa\.\w+/view/.*/


### PR DESCRIPTION
some userscripts make urls to go to this instead of to torrents.php. appears identical to torrents.php, doesn't hurt.