### PR TITLE
Add sportcult tracker support

### DIFF
--- a/quiCKIE.user.js
+++ b/quiCKIE.user.js
@@ -1598,7 +1598,7 @@ if ( primaryDomain == 'animebytes' ) {
 
     let trackerHandlingOptions = {
         downloadElementsSelector: 'a[href^="download.php?id="], a[href^="https://sportscult.org/download.php?id="]',
-        bunnyButtonFontSize: '120%',
+        bunnyButtonFontSize: '140%',
         elementsSeparator: ' ',
     }
 

--- a/quiCKIE.user.js
+++ b/quiCKIE.user.js
@@ -1596,7 +1596,7 @@ if ( primaryDomain == 'animebytes' ) {
     // xbtit 3.5.1 based tracker
 
     let trackerHandlingOptions = {
-        downloadElementsSelector: 'a[href*="download.php?id="], a[href*="page=download"], a[href*="page=downloadcheck"]',
+        downloadElementsSelector: 'a[href^="download.php?id="], a[href^="https://sportscult.org/download.php?id="]',
         bunnyButtonFontSize: '120%',
         elementsSeparator: ' ',
     }

--- a/quiCKIE.user.js
+++ b/quiCKIE.user.js
@@ -1601,10 +1601,6 @@ if ( primaryDomain == 'animebytes' ) {
         elementsSeparator: ' ',
     }
 
-    if ( pageURL.match(/index\.php\?page=torrents/) ) {
-        trackerHandlingOptions.enablePaginationLooping = true
-    }
-
     quickieTrackerHandler(trackerHandlingOptions)
 
         

--- a/quiCKIE.user.js
+++ b/quiCKIE.user.js
@@ -219,6 +219,8 @@
 // @match   https://secret-cinema.pw/top10.php*
 // @match   https://secret-cinema.pw/torrents.php*
 
+// @match   https://sportscult.org/index.php?page=torrents*
+
 // @match   https://thegeeks.click/browse.php*
 // @match   https://thegeeks.click/details.php?id=*
 
@@ -534,6 +536,12 @@ const settingsPanelTrackers = [
         trackerName: 'Secret-Cinema', // @tartuffe
         homepageURL: 'https://secret-cinema.pw',
         primaryDomain: 'secret-cinema',
+    },
+
+    {
+        trackerName: 'SportCult', // @steventrux
+        homepageURL: 'https://sportscult.org',
+        primaryDomain: 'sportscult',
     },
 
     {
@@ -1582,6 +1590,24 @@ if ( primaryDomain == 'animebytes' ) {
 
     quickieTrackerHandler(trackerHandlingOptions)
 
+} else if ( primaryDomain == 'sportscult' ) {
+    // ----------------------------------- SportCult -----------------------------------
+    // Browse
+    // xbtit 3.5.1 based tracker
+
+    let trackerHandlingOptions = {
+        downloadElementsSelector: 'a[href*="download.php?id="], a[href*="page=download"], a[href*="page=downloadcheck"]',
+        bunnyButtonFontSize: '120%',
+        elementsSeparator: ' ',
+    }
+
+    if ( pageURL.match(/index\.php\?page=torrents/) ) {
+        trackerHandlingOptions.enablePaginationLooping = true
+    }
+
+    quickieTrackerHandler(trackerHandlingOptions)
+
+        
 } else if ( primaryDomain == 'thegeeks' ) {
     // ----------------------------------- TheGeeks -----------------------------------
     // Browse | Details

--- a/quiCKIE.user.js
+++ b/quiCKIE.user.js
@@ -1602,7 +1602,6 @@ if ( primaryDomain == 'animebytes' ) {
     }
 
     quickieTrackerHandler(trackerHandlingOptions)
-
         
 } else if ( primaryDomain == 'thegeeks' ) {
     // ----------------------------------- TheGeeks -----------------------------------

--- a/quiCKIE.user.js
+++ b/quiCKIE.user.js
@@ -220,6 +220,7 @@
 // @match   https://secret-cinema.pw/torrents.php*
 
 // @match   https://sportscult.org/index.php?page=torrents*
+// @match   https://sportscult.org/index.php?page=torrent-details*
 
 // @match   https://thegeeks.click/browse.php*
 // @match   https://thegeeks.click/details.php?id=*
@@ -1592,7 +1593,7 @@ if ( primaryDomain == 'animebytes' ) {
 
 } else if ( primaryDomain == 'sportscult' ) {
     // ----------------------------------- SportCult -----------------------------------
-    // Browse
+    // Browse | Details
     // xbtit 3.5.1 based tracker
 
     let trackerHandlingOptions = {


### PR DESCRIPTION
Adds basic SportCult tracker support.

SportCult uses an xbtit 3.5.1 based layout and exposes torrent download links in the format:

`download.php?id=...&f=....torrent`

Tested on:

`https://sportscult.org/index.php?page=torrents`

The selected download link selector returns the expected torrent download links and BunnyButtons are created correctly.

Snatched/seeding emojiography is not included because the page does not appear to expose a reliable DOM indicator for already downloaded torrents.